### PR TITLE
Multiple permissions fixes

### DIFF
--- a/fpan/management/commands/add_accounts.py
+++ b/fpan/management/commands/add_accounts.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             return
 
         if options['land_managers'] is True:
-            load_fpan_state_auth(options['fake_passwords'])
+            load_fpan_state_auth(fake_passwords=options['fake_passwords'])
 
         if options['mock_scouts'] is True:
             create_mock_scout_accounts()

--- a/fpan/utils/fpan_account_creation.py
+++ b/fpan/utils/fpan_account_creation.py
@@ -184,6 +184,8 @@ def load_fpan_state_auth(fake_passwords=False):
             if fake_passwords:
                 pw = ma.nickname
             user = User.objects.get_or_create(username=name)[0]
+            user.set_password(pw)
+            user.save()
             user.groups.add(group)
             user.save()
             created_users.append((user,pw))

--- a/fpan/utils/permission_backend.py
+++ b/fpan/utils/permission_backend.py
@@ -2,6 +2,9 @@ from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.elasticsearch_dsl_builder import Query, Bool, Match, Terms, Nested
 from arches.app.models.models import Node, ResourceInstance
 from hms.models import Scout
+from fpan.models import ManagedArea
+from arches.app.models.system_settings import settings
+settings.update_from_db()
 # from fpan.utils.filter import get_match_conditions
 
 
@@ -95,11 +98,11 @@ def get_state_node_match(user):
 
     # The FL_BAR user gets full access to all sites
     if user.groups.filter(name="FL_BAR").exists():
-        return False
+        return "full_access"
 
     # The FMSF user gets full access to all sites
     if user.groups.filter(name="FMSF").exists():
-        return False
+        return "full_access"
 
     elif user.groups.filter(name="StatePark").exists():
 
@@ -129,7 +132,7 @@ def get_state_node_match(user):
         else:
             try:
                 park = ManagedArea.objects.get(nickname=user.username)
-            except:
+            except ManagedArea.DoesNotExist:
                 return "no_access"
 
             return {


### PR DESCRIPTION
This PR contains fixes for a few interrelated problems, generally having to do with some oversights in the way matching criteria were defined to determine access for state accounts. #95, #87, and #83 should be addressed with this PR.