### PR TITLE
fix username reference

### DIFF
--- a/fpan/utils/permission_backend.py
+++ b/fpan/utils/permission_backend.py
@@ -187,7 +187,7 @@ def get_state_node_match(user):
 
     elif user.groups.filter(name="FL_WMD").exists():
 
-        if user.username == "SJRWMD":
+        if user.username == "SJRWMD_Admin":
             return {
                 'node_name': "Managed Area Category",
                 'value': "Water Management District"


### PR DESCRIPTION
Fixes a final bug with the WMD Land Manager accounts. #101 now fully addressed.