### PR TITLE
removed resource id from map popup

### DIFF
--- a/fpan/templates/views/components/map-popup.htm
+++ b/fpan/templates/views/components/map-popup.htm
@@ -1,0 +1,49 @@
+{% load i18n %}
+{% load template_tags %}
+
+<!-- ko if: loading() -->
+<div class="hover-feature-body hover-feature-loading">
+    <i class="fa fa-spin fa-spinner"></i>
+    {% trans "Loading..." %}
+</div>
+<!--/ko-->
+
+<!-- ko if: !loading() -->
+<div class="hover-feature-title-bar">
+    {% block title %}
+    <div class="hover-feature-title">
+        <!-- Add nav to support accessing content for multiple features with overlapping geometry -->
+        <span class="hover-feature-nav-left disabled"><i class="fa fa-angle-left"></i></span>
+        <span class="" data-bind="text: displayname"></span>
+        <span class="hover-feature-nav-right disabled"><i class="fa fa-angle-right"></i></span>
+    </div>
+    {% endblock title %}
+</div>
+<div class="hover-feature-body">
+    {% block body %}
+    <div class="hover-feature" data-bind="html: map_popup"></div>
+    <div class="hover-feature-metadata">
+        {% trans "Resource Model:" %}
+        <span data-bind="text: graph_name"></span>
+    </div>
+    {% endblock body %}
+</div>
+<div class="hover-feature-footer">
+    {% block footer %}
+    <a data-bind="click: function () {
+        window.open(reportURL + resourceinstanceid());
+    }" href="javascript:void(0)">
+        <i class="ion-document-text"></i>
+        {% trans "Report" %}
+    </a>
+    {% if request.user|can_edit_resource_instance %}
+    <a data-bind="click: function () {
+        window.open(editURL + resourceinstanceid());
+    }" href="javascript:void(0)">
+        <i class="ion-ios-refresh-empty"></i>
+        {% trans "Edit" %}
+    </a>
+    {% endif %}
+    {% endblock footer %}
+</div>
+<!--/ko-->


### PR DESCRIPTION
overriding the map popup template to remove resource id across all resource models. 