### PR TITLE
124 scout report filter

### DIFF
--- a/fpan/management/commands/extension.py
+++ b/fpan/management/commands/extension.py
@@ -196,6 +196,17 @@ class Command(BaseCommand):
             instance.defaultconfig = details["defaultconfig"]
             instance.component = details["component"]
             instance.save()
+        
+        if extension_type == "search":
+            instance = model.objects.get(name=details["name"])
+            instance.icon = details["icon"]
+            instance.classname = details["classname"]
+            instance.type = details["type"]
+            instance.componentpath = details["componentpath"]
+            instance.componentname = details["componentname"]
+            instance.sortorder = details["sortorder"]
+            instance.enabled = details["enabled"]
+            instance.save()
 
     def unregister(self, extension_type, name):
         """

--- a/fpan/media/js/views/components/search/scout-report-filter.js
+++ b/fpan/media/js/views/components/search/scout-report-filter.js
@@ -1,0 +1,29 @@
+define([
+    'knockout',
+    'views/components/search/base-filter',
+], function(ko, BaseFilter) {
+    var componentName = 'scout-report-filter';
+    return ko.components.register(componentName, {
+        viewModel: BaseFilter.extend({
+            initialize: function(options) {
+                options.name = 'Scout Report Filter';
+                BaseFilter.prototype.initialize.call(this, options);
+            },
+
+            enabled: ko.observable(false),
+
+            updateQuery: function() {
+                this.enabled(!this.enabled())                
+                var queryObj = this.query();
+                if(this.enabled()){
+                    queryObj[componentName] = 'enabled';
+                } else {
+                    delete queryObj[componentName];
+                }
+                this.query(queryObj);
+            },
+
+        }),
+        template: { require: 'text!templates/views/components/search/scout-report-filter.htm' }
+    });
+});

--- a/fpan/search/components/scout_report_filter.py
+++ b/fpan/search/components/scout_report_filter.py
@@ -29,7 +29,7 @@ class ScoutReportFilter(BaseSearchFilter):
         This is the method that Arches calls, and ultimately all it does is
 
           search_results_object["query"].add_query(some_new_es_dsl)
-        
+
         Only proceed with the replacement of the query if the filter is enabled.
         """
 
@@ -47,8 +47,9 @@ class ScoutReportFilter(BaseSearchFilter):
             report_tiles = Tile.objects.filter(resourceinstance__graph__name="Scout Report", nodegroup=site_node.nodegroup)
             reportids = []
             for t in report_tiles:
-                if t.data[str(site_node.pk)][0]['resourceId'] in resids:
-                    reportids.append(str(t.resourceinstance_id))
+                if len(t.data[str(site_node.pk)]) > 0:
+                    if t.data[str(site_node.pk)][0]['resourceId'] in resids:
+                        reportids.append(str(t.resourceinstance_id))
 
             # create new query using ids for the scout reports
             se = SearchEngineFactory().create()

--- a/fpan/search/components/scout_report_filter.py
+++ b/fpan/search/components/scout_report_filter.py
@@ -1,0 +1,66 @@
+import logging
+
+from arches.app.search.search_engine_factory import SearchEngineFactory
+from arches.app.search.elasticsearch_dsl_builder import Bool, Terms, Query
+from arches.app.search.components.base import BaseSearchFilter
+from arches.app.search.mappings import RESOURCES_INDEX
+from arches.app.models.models import Node
+from arches.app.models.tile import Tile
+
+logger = logging.getLogger(__name__)
+
+details = {
+    "searchcomponentid": "",
+    "name": "Scout Report Filter",
+    "icon": "fa fa-binoculars",
+    "modulename": "scout_report_filter.py",
+    "classname": "ScoutReportFilter",
+    "type": "popup",
+    "componentpath": "views/components/search/scout-report-filter",
+    "componentname": "scout-report-filter",
+    "sortorder": "100",
+    "enabled": True,
+}
+
+class ScoutReportFilter(BaseSearchFilter):
+
+    def append_dsl(self, search_results_object, permitted_nodegroups, include_provisional):
+        """
+        This is the method that Arches calls, and ultimately all it does is
+
+          search_results_object["query"].add_query(some_new_es_dsl)
+        
+        Only proceed with the replacement of the query if the filter is enabled.
+        """
+
+        if self.request.GET.get(details["componentname"]) == "enabled":
+
+            # get original results here, and iterate them to get the ids to look for
+            # in Scout Reports
+            search_results_object["query"].limit = 10000
+            results = search_results_object["query"].search(index=RESOURCES_INDEX)
+            resids = set([i['_source']['resourceinstanceid'] for i in results['hits']['hits']])
+
+            # now look through all Scout Report tiles to return ids of the ones that reference
+            # the sites from the query.
+            site_node = Node.objects.get(name="FMSF Site ID", graph__name="Scout Report")
+            report_tiles = Tile.objects.filter(resourceinstance__graph__name="Scout Report", nodegroup=site_node.nodegroup)
+            reportids = []
+            for t in report_tiles:
+                if t.data[str(site_node.pk)][0]['resourceId'] in resids:
+                    reportids.append(str(t.resourceinstance_id))
+
+            # create new query using ids for the scout reports
+            se = SearchEngineFactory().create()
+            query = Query(se, limit=10000)
+
+            new_bool = Bool()
+            terms = Terms(
+                field='resourceinstanceid',
+                terms=reportids
+            )
+            new_bool.must(terms)
+            query.add_query(new_bool)
+
+            # replace original query object with new query
+            search_results_object["query"] = query

--- a/fpan/templates/views/components/search/rule-filter.htm
+++ b/fpan/templates/views/components/search/rule-filter.htm
@@ -1,3 +1,5 @@
-<div style="padding:15px">
-{{ site_access_html|safe }}
+<div style="padding: 0px 15px;"">
+    <div class="filter-title">Archaeological Site Access</div>
+    <hr class="title-underline">
+    <p>{{ site_access_html|safe }}</p>
 </div>

--- a/fpan/templates/views/components/search/scout-report-filter.htm
+++ b/fpan/templates/views/components/search/scout-report-filter.htm
@@ -1,0 +1,7 @@
+<div style="padding: 0px 15px;"">
+    <div class="filter-title">Scout Report Filter</div>
+    <hr class="title-underline">
+    <p>Show all Scout Reports for the current search results. You must have less than 10,000 search results for this filter to work properly.</p>
+    <p><em>If you change the underlying query, you may need to Disable/Enable.</em></p>
+    <button data-bind="click: updateQuery, text: enabled() ? 'Disable' : 'Enable' "></button>
+</div>


### PR DESCRIPTION
Adds a new custom search filter that shows the related Scout Reports for all resources in the current search results.

The filter works by running the existing query "early" to obtain the resource ids of all the current search results, and then checking those ids against all Scout Report "FMSF Site ID" node values. The ids of matching reports are inserted into a new ES query which is swapped out for the original one before being "returned" to Arches to be run.

Closes #124.