### PR TITLE
Fix Scout Report Printing (Issue #292 Partial)

### DIFF
--- a/fpan/media/css/index.css
+++ b/fpan/media/css/index.css
@@ -591,11 +591,10 @@ input[type='text'] {
 
   /* we never want to print backgrounds -- override Chrome print dialog > Options > Background graphics = checked */ 
   *,
-  /* Chrome ignores this for the brand header .brand-scout-report, so be more specific */
-  .brand-title
+  .brand-title /* Chrome ignores this for the brand header, requiring more specificity */
   {
     background: none !important;
-    color: black;
+    color: black !important;
   }
   
   body {
@@ -684,7 +683,7 @@ input[type='text'] {
       grid-column: 1;
     }
 
-    /* when a dt has multiple dd's, unsure all dd's align right */
+    /* when a dt has multiple dd's, ensure all dd's align right */
     dd { grid-column: 2; }
 
     /* add space between label:value lines */

--- a/fpan/media/css/index.css
+++ b/fpan/media/css/index.css
@@ -583,7 +583,7 @@ input[type='text'] {
   color: #555;
 }
 
-/* applies to scout reports only, but no code enforces this */
+/* applies to scout reports only */
 @media print {
   :root {
     --printed-font-size: 0.8rem;
@@ -595,7 +595,7 @@ input[type='text'] {
 
   @page {
     margin-inline: 0.75in;
-    border: 1px solid red;
+    margin-block: 0.5in;
   }
   
   /* hide for printing */
@@ -608,13 +608,46 @@ input[type='text'] {
     display: none !important;
   }
 
-  /* don't page break inside of these elements */
-  /* card sections containing single imgs (results when user selects one image for upload, then clicks "+ Add" button) -- implies: OK to break inside card sections with multiple images */
-  .rp-card-section[id]:has(img):not(:has(img ~ img)),
-  img {
+  /* card sections containing single imgs (results when user selects one image for upload, then clicks "+ Add" button) */
+  .rp-card-section[id]:has(.rp-image-grid-item) {
     page-break-inside: avoid;
   }
+  
+  /* card sections containing multiple images (results when user selects multiple images for upload, then clicks "+ Add" button) */
+  .rp-card-section[id]:has(.rp-image-grid-item ~ .rp-image-grid-item) {
+    page-break-before: avoid;
+  }
 
+  /* add space between images with sibling image */
+  .rp-image-grid-item:not(:first-child) {
+    margin-top: calc(var(--printed-font-size) * 1);
+  }
+  
+  /* put site logo and brand text into a single row */
+  .navbar-header a {
+    display: grid;
+    grid-template-columns: 1fr 100fr;
+    gap: 0 calc(var(--printed-font-size) * 1);
+
+    .brand-title {
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  /* align 'Scout Report - <date> - <user>' page title with following headers */
+  .report-toolbar-title {
+    margin-block: calc(var(--printed-font-size) * 1);
+    margin-inline: 0;
+  }
+
+  /* split the page/report title and 'Report Date' across the page */
+  .report-toolbar-preview.ep-form-toolbar {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  /* increase margins of <hr> */
   .rp-tile-separator {
     margin-block: 1rem;
   }
@@ -630,10 +663,14 @@ input[type='text'] {
     font-size: calc(var(--printed-font-size) * 1.15);
   }
 
+  /* force field labels and values onto the same row */
   dl {
     display: grid;
     /* make more room for field values, without causing labels, which would force the 2nd+ line of the following value to be set too far down */
     grid-template-columns: 1fr 2fr;
+
+    /* match alignment of field labels to web view */
+    dt { text-align: end; }
 
     /* add space between label:value lines */
     dt, dd { margin-bottom: calc(var(--printed-font-size) * 0.8); }
@@ -642,13 +679,14 @@ input[type='text'] {
     p:first-child { margin-top: 0; }
   }
 
-  /* selects cards containing actual resource data, with the data being an image */
+  /* selects cards containing actual resource data, where the data is an image */
   .rp-card-section[id]:has(img) {
       width: 100%;
 
-      /* make alignment more visually pleasing in cards with images inside -- decrease label and increase value col widths -- stops values (eg Overview, Unique Feature, <comment>, etc) from looking like there was a failed attempt at centering text */
+      /* make alignment more visually pleasing in cards with images inside, since images are centered and possibly full-width -- decrease label and increase value col widths -- stops values (eg Overview, Unique Feature, <comment>, etc) from looking like there was a failed attempt at centering text */
       dl { grid-template-columns: 1fr 8fr; }
-      dd { margin-left: 0 }
+      dt { text-align: start; }
+      dd { margin-inline-start: 0; }
   }
 
   dd:has(img) {
@@ -658,7 +696,7 @@ input[type='text'] {
     /* center the image */
     text-align: center;
     
-    /* hide the image files label */
+    /* hide the image files label and vertical space */
     margin-top: calc(var(--printed-font-size) * 2.4 * -1);
     background: white;
     z-index: 100;

--- a/fpan/media/css/index.css
+++ b/fpan/media/css/index.css
@@ -582,3 +582,77 @@ input[type='text'] {
 .profile-label-shim {
   color: #555;
 }
+
+/* applies to scout reports only, but no code enforces this */
+@media print {
+  
+  body {
+    width: 8.5in;
+    padding-block: 0.8in;
+    padding-inline: 0.5in;
+  }
+  
+  /* hide for printing */
+  #mainnav-container,
+  .carousel,
+  .ep-toolbar,
+  .toggle-container,
+  button#scroll-top,
+  footer {
+    display: none !important;
+  }
+
+  /* don't page break inside of these elements */
+  /* card sections containing single imgs (results when user selects one image for upload, then clicks "+ Add" button) -- implies: OK to break inside card sections with multiple images */
+  .rp-card-section[id]:has(img):not(:has(img ~ img)),
+  img {
+    page-break-inside: avoid;
+  }
+
+  .rp-tile-separator {
+    margin-block: 1rem;
+  }
+  
+  /* <dt> = field labels */
+  dt,
+  .rp-tile-title {
+    font-weight: bold;
+  }
+
+  .rp-tile-title {
+    text-decoration: underline;
+    font-size: 1.15rem;
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+
+    /* add space between label:value lines */
+    dt, dd { margin-bottom: 1rem; }
+    
+    /* keep vertical gap bt rows consistent when the field value is paragraph text instead of text directly inside the <dd> */
+    p:first-child { margin-top: 0; }
+  }
+
+  /* selects cards containing actual resource data, with the data being an image */
+  .rp-card-section[id]:has(img) {
+      width: 100%;
+      
+      /* make alignment more visually pleasing in cards with images inside -- decrease label and increase value col widths -- stops values (eg Overview, Unique Feature, <comment>, etc) from looking like there was a failed attempt at centering text */
+      dl { grid-template-columns: 1fr 7fr; }
+  }
+
+  dd:has(img) {
+    margin: 0;
+    /* make img 100% width of dd that contains it */
+    grid-column: 1 / -1;
+    /* center the image */
+    text-align: center;
+  }
+
+  dd img {
+    max-width: 100%;
+    max-height: 4in;
+  }
+}

--- a/fpan/media/css/index.css
+++ b/fpan/media/css/index.css
@@ -585,11 +585,17 @@ input[type='text'] {
 
 /* applies to scout reports only, but no code enforces this */
 @media print {
+  :root {
+    --printed-font-size: 0.8rem;
+  }
   
   body {
-    width: 8.5in;
-    padding-block: 0.8in;
-    padding-inline: 0.5in;
+    font-size: var(--printed-font-size);
+  }
+
+  @page {
+    margin-inline: 0.75in;
+    border: 1px solid red;
   }
   
   /* hide for printing */
@@ -621,15 +627,16 @@ input[type='text'] {
 
   .rp-tile-title {
     text-decoration: underline;
-    font-size: 1.15rem;
+    font-size: calc(var(--printed-font-size) * 1.15);
   }
 
   dl {
     display: grid;
+    /* make more room for field values, without causing labels, which would force the 2nd+ line of the following value to be set too far down */
     grid-template-columns: 1fr 2fr;
 
     /* add space between label:value lines */
-    dt, dd { margin-bottom: 1rem; }
+    dt, dd { margin-bottom: calc(var(--printed-font-size) * 0.8); }
     
     /* keep vertical gap bt rows consistent when the field value is paragraph text instead of text directly inside the <dd> */
     p:first-child { margin-top: 0; }
@@ -638,9 +645,10 @@ input[type='text'] {
   /* selects cards containing actual resource data, with the data being an image */
   .rp-card-section[id]:has(img) {
       width: 100%;
-      
+
       /* make alignment more visually pleasing in cards with images inside -- decrease label and increase value col widths -- stops values (eg Overview, Unique Feature, <comment>, etc) from looking like there was a failed attempt at centering text */
-      dl { grid-template-columns: 1fr 7fr; }
+      dl { grid-template-columns: 1fr 8fr; }
+      dd { margin-left: 0 }
   }
 
   dd:has(img) {
@@ -649,10 +657,16 @@ input[type='text'] {
     grid-column: 1 / -1;
     /* center the image */
     text-align: center;
+    
+    /* hide the image files label */
+    margin-top: calc(var(--printed-font-size) * 2.4 * -1);
+    background: white;
+    z-index: 100;
+      
   }
 
   dd img {
     max-width: 100%;
-    max-height: 4in;
+    max-height: 3.9in;
   }
 }

--- a/fpan/media/css/index.css
+++ b/fpan/media/css/index.css
@@ -588,6 +588,15 @@ input[type='text'] {
   :root {
     --printed-font-size: 0.8rem;
   }
+
+  /* we never want to print backgrounds -- override Chrome print dialog > Options > Background graphics = checked */ 
+  *,
+  /* Chrome ignores this for the brand header .brand-scout-report, so be more specific */
+  .brand-title
+  {
+    background: none !important;
+    color: black;
+  }
   
   body {
     font-size: var(--printed-font-size);
@@ -707,4 +716,7 @@ input[type='text'] {
     max-width: 100%;
     max-height: 3.9in;
   }
+
+  /* keeping above in case we decide we want images in the future, but for now, hide all images */
+  .rp-card-section:has(img) { display: none; }
 }

--- a/fpan/media/css/index.css
+++ b/fpan/media/css/index.css
@@ -666,7 +666,7 @@ input[type='text'] {
   /* force field labels and values onto the same row */
   dl {
     display: grid;
-    /* make more room for field values, without causing labels, which would force the 2nd+ line of the following value to be set too far down */
+    /* make more room for field values, without causing labels to wrap, which would force the 2nd+ line of the following value to be set too far down */
     grid-template-columns: 1fr 2fr;
 
     /* match alignment of field labels to web view */
@@ -696,7 +696,7 @@ input[type='text'] {
     /* center the image */
     text-align: center;
     
-    /* hide the image files label and vertical space */
+    /* hide the image files label, buying more vertical space to keep images as large as possible (up to half a page height) */
     margin-top: calc(var(--printed-font-size) * 2.4 * -1);
     background: white;
     z-index: 100;

--- a/fpan/media/css/index.css
+++ b/fpan/media/css/index.css
@@ -679,7 +679,13 @@ input[type='text'] {
     grid-template-columns: 1fr 2fr;
 
     /* match alignment of field labels to web view */
-    dt { text-align: end; }
+    dt {
+      text-align: end;
+      grid-column: 1;
+    }
+
+    /* when a dt has multiple dd's, unsure all dd's align right */
+    dd { grid-column: 2; }
 
     /* add space between label:value lines */
     dt, dd { margin-bottom: calc(var(--printed-font-size) * 0.8); }

--- a/fpan/templates/base-manager.htm
+++ b/fpan/templates/base-manager.htm
@@ -168,7 +168,7 @@
                                 print()
                                 return
                               }
-                              const msg = "⚠️ Scout Report printing is only supported on desktop Chrome browser. Formatting may be inconsistent when printing from other devices or browsers."
+                              const msg = "⚠️ Scout Report printing is only fully supported on desktop Chrome browser. Formatting may be inconsistent when printing from other devices or browsers."
                               if (!confirm(msg)) return
                               print()
                             }

--- a/fpan/templates/base-manager.htm
+++ b/fpan/templates/base-manager.htm
@@ -148,7 +148,32 @@
                         {% endif %}
 
                         {% if nav.print %}
-                        <a href="" class="ep-tools ep-tools-right" data-bind="click: function() { window.print() }">
+                        <script>
+                            /** Intercept print keyboard shortcut and print button press to
+                            provide message about browser compat, only when viewing a Scout Report. */
+                            
+                            addEventListener('keydown', onPrintShortcut)
+                            
+                            function onPrintShortcut(e) {
+                              if (!e.metaKey && !e.ctrlKey ) return
+                              if (e.key === 'p') {
+                                e.preventDefault()
+                                printScoutReport()
+                              }
+                            }
+                            
+                            function printScoutReport() {
+                              // don't interfere with printing if not in a Scout Report view
+                              if (!location.pathname.startsWith('/report')) {
+                                print()
+                                return
+                              }
+                              const msg = "⚠️ Scout Report printing is only supported on desktop Chrome browser. Formatting may be inconsistent when printing from other devices or browsers."
+                              if (!confirm(msg)) return
+                              print()
+                            }
+                        </script>
+                        <a href="" class="ep-tools ep-tools-right" data-bind="click: printScoutReport">
                             <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title='{% trans "Print" %}'>
                               <i class="ion-printer"></i>
                             </div>


### PR DESCRIPTION
Partially address #292 -- does not include image download feature.

This change allows users to print scout reports. From the print dialog, users can save a PDF. Printing is only supported on desktop Chrome.

