### PR TITLE
300 spatial join trigger on resource creation/edit

### DIFF
--- a/fpan/apps.py
+++ b/fpan/apps.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 from django.apps import AppConfig
 
 
-class HmsConfig(AppConfig):
-    name = 'hms'
+class FpanConfig(AppConfig):
+    name = 'fpan'
 
     def ready(self):
         from . import signals  # noqa: F401

--- a/fpan/management/commands/spatial_join.py
+++ b/fpan/management/commands/spatial_join.py
@@ -5,13 +5,14 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from arches.app.models.models import ResourceInstance
 from arches.app.models.graph import Graph
+from arches.app.models.tile import Tile
 
 from fpan.utils import SpatialJoin
 from fpan.tasks import run_full_spatial_join
 
 class Command(BaseCommand):
 
-    help = 'export all of the FMSF site ids from resources in the database'
+    help = "Performs a spatial join between the management areas and resources"
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -23,7 +24,15 @@ class Command(BaseCommand):
             action="store_true",
         )
         parser.add_argument(
+            '--backfill',
+            action="store_true",
+        )
+        parser.add_argument(
             '--background',
+            action="store_true",
+        )
+        parser.add_argument(
+            '--noinput',
             action="store_true",
         )
 
@@ -42,6 +51,20 @@ class Command(BaseCommand):
                 "Historic Cemetery",
                 "Historic Structure",
             ])
+        elif options["backfill"]:
+            # find all empty FPAN Region nodes and use only these resources
+            resids = []
+            for k, v in settings.SPATIAL_JOIN_GRAPHID_LOOKUP.items():
+                print(k)
+                tiles = Tile.objects.filter(nodegroup_id=v['Nodegroup'])
+                empty_tiles = [i for i in tiles if i.data and not i.data[v["FPAN Region"]]]
+                print(f"resources to join: {len(empty_tiles)}")
+                resids += [i.resourceinstance.pk for i in empty_tiles]
+            resources = ResourceInstance.objects.filter(pk__in=resids)
+            print(f"\ntotal resources: {resources.count()}")
+            if not options["noinput"]:
+                if input("continue? Y/n").lower().startswith("n"):
+                    exit()
         else:
             exit()
 

--- a/fpan/settings.py
+++ b/fpan/settings.py
@@ -161,6 +161,12 @@ SPATIAL_JOIN_GRAPHID_LOOKUP = {
     },
 }
 
+SPATIAL_COORDINATES_NODEGROUPS_IDS = [
+    "3067ed10-dbaa-11e7-87be-94659cf754d0", # archaeological site
+    "210c6341-dbab-11e7-9832-94659cf754d0", # historic cemetery
+    "efe6cb5e-dbab-11e7-a327-94659cf754d0", # historic structure
+]
+
 try:
     from .settings_local import *
 except ImportError as e:

--- a/fpan/signals.py
+++ b/fpan/signals.py
@@ -1,0 +1,22 @@
+import logging
+
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from arches.app.models.tile import Tile
+
+logger = logging.getLogger(__name__)
+
+@receiver(post_save, sender=Tile)
+def join_management_areas_to_resourceinstance(sender, instance, created, **kwargs):
+    from .utils import SpatialJoin
+
+    if instance.nodegroup_id in settings.SPATIAL_COORDINATES_NODEGROUPS_IDS:
+
+        logger.debug(f"run spatial join on resource: {instance.resourceinstance_id}")
+        try:
+            joiner = SpatialJoin()
+            joiner.update_resource(instance.resourceinstance)
+        except Exception as e:
+            logger.error(f"error encoutered: {e}")


### PR DESCRIPTION
Closes #300 

As described in #300, newly added resources were not getting their Management nodes populated, which needs to happen via a spatial join against all Management Area objects in the db. The problem was just that this operation had only been setup to run after a bulk upload of FMSF data, or an upload of new Management Areas--it wasn't hooked up to run when a new site was created, or an existing site had its coordinates altered. To address this I added a signal receiver to run whenever a spatial coordinates node is saved.

@kkemp85 One note: After you create or modify the coordinates of a resource (site, cemetery, structure), the process will run and populate the Management attributes when you click Save. However, you'll need to refresh the editor page before those attributes will show up as populated.

I've also added a `--backfill` argument to the existing `spatial_join` management command, which looks for any resources that don't have management information already (based on presence of the FPAN Region node). This lookup needs to happen in two ways:

- Resources that don't have a tile present at all for the Management Area nodegroup
- Resources that have a tile but FPAN Region is empty in it

I've run this backfilling on the whole database, and there were 1170 resources that needed to be updated. After completion (took 20 min so 1.025 seconds per resource), there are still 400 resources (383 sites, 2 cemeteries, 15 structures) that are missing FPAN Region info. This is because these are all off the coast, and the FPAN Region boundaries I had loaded into the system end at the coastline. I'll make a separate ticket for updating those geometries and finalizing this run.